### PR TITLE
🐛 Fix: 체크상태 체크 기준을 살아있는 기물만으로 제한하여 해결

### DIFF
--- a/chessGame/src/chessGame/ChessBoard.java
+++ b/chessGame/src/chessGame/ChessBoard.java
@@ -286,7 +286,10 @@ public class ChessBoard extends JFrame {
 
 		// 상대 기물들의 공격 가능 위치 확인
 		for (int i = 0; i < opponentPieces.size(); i++) {
+			// 활성화가 되어있는 말만 적용되도록 해야함(아니면 죽은 말도 체크 여부에 포함됨)
+			if(opponentPieces.get(i).isEnabled()) {
 			opponentPieces.get(i).isAttackKing();
+			}
 		}
 
 		// 킹의 아이콘이 공격 아이콘으로 변경되었는지 확인


### PR DESCRIPTION
체크상태를 확인할 때 공격받아 죽은 기물도 포함하여 확인해 버그가 발생
살아있는 말만 확인하도록 제한을 줘서 해결